### PR TITLE
Increase popover height and add expand/collapse view

### DIFF
--- a/Sources/ClearDisk/ClearDiskApp.swift
+++ b/Sources/ClearDisk/ClearDiskApp.swift
@@ -37,7 +37,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Create popover
         popover = NSPopover()
-        popover.contentSize = NSSize(width: 380, height: 540)
+        popover.contentSize = NSSize(width: 380, height: 700)
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(
             rootView: MainView(diskMonitor: diskMonitor)

--- a/Sources/ClearDisk/MainView.swift
+++ b/Sources/ClearDisk/MainView.swift
@@ -18,6 +18,7 @@ struct MainView: View {
     @State private var showCleanSelectedCachesConfirm = false
     @State private var projectFilterMode: ProjectFilterMode = .all
     @State private var isCleaning = false
+    @State private var isExpanded = false
     
     enum Tab: String, CaseIterable {
         case developer = "Developer"
@@ -59,7 +60,7 @@ struct MainView: View {
                 mainScreen
             }
         }
-        .frame(width: 380, height: 540)
+        .frame(width: 380, height: 700)
         .alert("Clean Cache", isPresented: $showCleanConfirm) {
             Button("Cancel", role: .cancel) { }
             Button("Move to Trash", role: .destructive) {
@@ -156,49 +157,130 @@ struct MainView: View {
     // MARK: - Main Screen
     var mainScreen: some View {
         ZStack {
-            VStack(spacing: 0) {
-                // Header
-                headerView
-                
-                Divider()
-                
-                // Permission warnings (if any)
-                if diskMonitor.notificationPermission == .denied {
-                    permissionBanner
-                    Divider()
-                }
-                
-                // Cleanable summary card (only when there's stuff to clean)
-                let artifactTotal = diskMonitor.projectArtifacts.reduce(Int64(0)) { $0 + $1.size }
-                if diskMonitor.safeCleanable > 10_485_760 || diskMonitor.riskyCleanable > 10_485_760 || artifactTotal > 10_485_760 {
-                    cleanableSummary
-                    Divider()
-                }
-                
-                // Tab bar
-                tabBar
-                
-                Divider()
-                
-                // Content
-                ScrollView {
-                    switch selectedTab {
-                    case .overview:
-                        overviewContent
-                    case .developer:
-                        developerContent
-                    case .projects:
-                        projectsContent
-                    case .largeFiles:
-                        largeFilesContent
+            if isExpanded {
+                // Expanded view: full-height content with back button
+                VStack(spacing: 0) {
+                    HStack {
+                        Button(action: { withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) { isExpanded = false } }) {
+                            HStack(spacing: 4) {
+                                Image(systemName: "chevron.left")
+                                    .font(.system(size: 11))
+                                Text("Back")
+                                    .font(.system(size: 12))
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 6)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundColor(.blue)
+                        
+                        Spacer()
+                        
+                        Text(selectedTab.rawValue)
+                            .font(.system(size: 13, weight: .semibold))
+                        
+                        Spacer()
+                        
+                        if diskMonitor.isScanning {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                        }
+                        Button(action: { diskMonitor.scan() }) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 12))
+                        }
+                        .buttonStyle(.plain)
+                        .help("Refresh")
                     }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    
+                    Divider()
+                    
+                    ScrollView {
+                        switch selectedTab {
+                        case .overview:
+                            overviewContent
+                        case .developer:
+                            developerContent
+                        case .projects:
+                            projectsContent
+                        case .largeFiles:
+                            largeFilesContent
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
+                    
+                    Divider()
+                    
+                    footerView
                 }
-                .frame(maxHeight: .infinity)
-                
-                Divider()
-                
-                // Footer
-                footerView
+                .transition(.asymmetric(
+                    insertion: .move(edge: .bottom).combined(with: .opacity),
+                    removal: .move(edge: .bottom).combined(with: .opacity)
+                ))
+            } else {
+                // Normal view
+                VStack(spacing: 0) {
+                    // Header
+                    headerView
+                    
+                    Divider()
+                    
+                    // Permission warnings (if any)
+                    if diskMonitor.notificationPermission == .denied {
+                        permissionBanner
+                        Divider()
+                    }
+                    
+                    // Cleanable summary card (only when there's stuff to clean)
+                    let artifactTotal = diskMonitor.projectArtifacts.reduce(Int64(0)) { $0 + $1.size }
+                    if diskMonitor.safeCleanable > 10_485_760 || diskMonitor.riskyCleanable > 10_485_760 || artifactTotal > 10_485_760 {
+                        cleanableSummary
+                        Divider()
+                    }
+                    
+                    // Tab bar with expand button
+                    HStack(spacing: 0) {
+                        tabBar
+                        
+                        Button(action: { withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) { isExpanded = true } }) {
+                            Image(systemName: "arrow.up.left.and.arrow.down.right")
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
+                                .frame(width: 32, height: 28)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    
+                    Divider()
+                    
+                    // Content
+                    ScrollView {
+                        switch selectedTab {
+                        case .overview:
+                            overviewContent
+                        case .developer:
+                            developerContent
+                        case .projects:
+                            projectsContent
+                        case .largeFiles:
+                            largeFilesContent
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
+                    
+                    Divider()
+                    
+                    // Footer
+                    footerView
+                }
+                .transition(.asymmetric(
+                    insertion: .move(edge: .top).combined(with: .opacity),
+                    removal: .move(edge: .top).combined(with: .opacity)
+                ))
             }
             
             // Onboarding overlay (first launch)

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# ClearDisk dev script - build .app bundle, kill old, launch new
+set -e
+
+echo ">> Killing old ClearDisk..."
+pkill -f "ClearDisk" 2>/dev/null || true
+sleep 0.5
+
+echo ">> Building .app bundle..."
+./build_app.sh
+
+echo ">> Launching..."
+open ClearDisk.app
+
+echo ">> Done! Check menu bar."


### PR DESCRIPTION
Addresses #8

## Changes

- Increased popover height from 540 to 700px for better content visibility (~6 items visible vs ~3 before)
- Added expand/collapse button next to tab bar -- expands current tab to full-height view, hiding header and summary card
- Smooth spring animation on expand/collapse transitions
- Added dev.sh script for quick build-and-run workflow

## Screenshots


Normal
|--------|
<img width="377" height="695" alt="normal" src="https://github.com/user-attachments/assets/037a6ee8-91a2-4c9e-a4b1-20761fd47dcb" />

Expanded
|--------|
<img width="377" height="695" alt="expanded" src="https://github.com/user-attachments/assets/ea5841b2-4c72-44d8-9fc7-158b6ef0dcb3" />
