### PR TITLE
fix: correct Homebrew cask macOS dependency syntax

### DIFF
--- a/scripts/brew_update.sh
+++ b/scripts/brew_update.sh
@@ -34,7 +34,7 @@ cask "cleardisk" do
   desc "Free, open-source macOS app to find and clean developer caches"
   homepage "https://github.com/bysiber/cleardisk"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "ClearDisk.app"
 


### PR DESCRIPTION
This change sets minimum version to Sonoma and fixes the...

Warning: Calling string comparison format for depends_on macos: is deprecated! Use depends_on macos: :sonoma instead. Please report this issue to the bysiber/homebrew-cleardisk tap (not Homebrew/* repositories), or even better, submit a PR to fix it: /opt/homebrew/Library/Taps/bysiber/homebrew-cleardisk/Casks/cleardisk.rb:10

... error as reported by theeseuus in Issue #20.