### PR TITLE
Add universal binary support for Intel and Apple Silicon Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to ClearDisk are documented here.
 
+## [1.8.3] - Unreleased
+### Changed
+- Universal binary for Apple Silicon and Intel (`arm64` + `x86_64` via `lipo`)
+
 ## [1.8.2] - 2026-07-16
 ### Added
 - Added signed app produced pipeline to avoid `xattr -cr ...` quirk
-- Updated version derivation from scripts (version is read from `CHANGELOG.md`)
-
-### Changed
-- **Universal binary** — `scripts/build_app.sh` now builds `arm64` and `x86_64` (via `--triple`) and stitches them with `lipo`, so the DMG / `.app` run on both Apple Silicon and Intel Macs (macOS 14+). Release packaging asserts both slices are present. App size docs updated to ~6 MB (was outdated at 590 KB).
+- Updated version derivation from scripts
 
 ## [1.8.1] - 2026-07-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to ClearDisk are documented here.
 
+## [1.8.2] - 2026-07-14
+### Changed
+- **Universal binary** — `scripts/build_app.sh` now builds `arm64` and `x86_64` (via `--triple`) and stitches them with `lipo`, so the DMG / `.app` run on both Apple Silicon and Intel Macs (macOS 14+). Release packaging asserts both slices are present. App size docs updated to ~6 MB (was outdated at 590 KB).
+
 ## [1.8.1] - 2026-07-13
 ### Fixed
 - **No menu bar icon; the app appears to do nothing** (#22, #16). `NSApplication.delegate` is a *weak* reference, and nothing else in the app retained `AppDelegate` — every other reference to it captured `self` weakly. Held only by a local in `main()`, ARC was free to release it after its last use, before or during `app.run()`, taking the status item and the popover with it. The process kept running (some users still saw notification banners) but there was no menu bar icon and clicks went nowhere. Whether it happened at all depended on the optimiser, which is why it reproduced on some Macs and not others. The delegate is now held for the life of the process.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 **Your Mac is hiding 50–500 GB of developer caches. ClearDisk finds them in seconds.**
 
-A free, open-source macOS menu bar app that monitors and cleans developer caches, Xcode, npm, Homebrew, Docker, pip, Cargo, Go, Gradle, and more. ~6 MB universal binary. Zero dependencies. No data collection. No analytics. No network access. Ever.
+A free, open-source macOS menu bar app that monitors and cleans developer caches, Xcode, npm, Homebrew, Docker, pip, Cargo, Go, Gradle, and more. 590 KB. Zero dependencies. No data collection. No analytics. No network access. Ever.
 
 ![macOS 14+](https://img.shields.io/badge/macOS-14%2B-blue)
 ![Swift](https://img.shields.io/badge/Swift-5.9-orange)
 ![License: MIT](https://img.shields.io/badge/License-MIT-green)
-![Size](https://img.shields.io/badge/Size-~6%20MB-brightgreen)
+![Size](https://img.shields.io/badge/Size-590%20KB-brightgreen)
 [![GitHub stars](https://img.shields.io/github/stars/bysiber/cleardisk?style=social)](https://github.com/bysiber/cleardisk/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/bysiber/cleardisk)](https://github.com/bysiber/cleardisk/releases/latest)
 [![Homebrew](https://img.shields.io/badge/Homebrew-tap-brown)](https://github.com/bysiber/homebrew-cleardisk)

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 **Your Mac is hiding 50–500 GB of developer caches. ClearDisk finds them in seconds.**
 
-A free, open-source macOS menu bar app that monitors and cleans developer caches, Xcode, npm, Homebrew, Docker, pip, Cargo, Go, Gradle, and more. 590 KB. Zero dependencies. No data collection. No analytics. No network access. Ever.
+A free, open-source macOS menu bar app that monitors and cleans developer caches, Xcode, npm, Homebrew, Docker, pip, Cargo, Go, Gradle, and more. ~6 MB universal binary. Zero dependencies. No data collection. No analytics. No network access. Ever.
 
 ![macOS 14+](https://img.shields.io/badge/macOS-14%2B-blue)
 ![Swift](https://img.shields.io/badge/Swift-5.9-orange)
 ![License: MIT](https://img.shields.io/badge/License-MIT-green)
-![Size](https://img.shields.io/badge/Size-590%20KB-brightgreen)
+![Size](https://img.shields.io/badge/Size-~6%20MB-brightgreen)
 [![GitHub stars](https://img.shields.io/github/stars/bysiber/cleardisk?style=social)](https://github.com/bysiber/cleardisk/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/bysiber/cleardisk)](https://github.com/bysiber/cleardisk/releases/latest)
 [![Homebrew](https://img.shields.io/badge/Homebrew-tap-brown)](https://github.com/bysiber/homebrew-cleardisk)
@@ -109,7 +109,7 @@ That's it. Click the disk icon in your menu bar.
 
 > **Why the Gatekeeper warning?** ClearDisk is not notarized with Apple ($99/yr Developer fee). The app is fully open-source -- you can verify every line of code yourself.
 
-Requires macOS 14+ (Apple Silicon). Xcode Command Line Tools needed for building from source (`xcode-select --install`).
+Requires macOS 14+ (Apple Silicon and Intel). Release builds are universal (`arm64` + `x86_64`). Xcode Command Line Tools needed for building from source (`xcode-select --install`).
 
 ## How It Works
 
@@ -193,7 +193,7 @@ CleanMyMac ($40/yr) is a general-purpose Mac cleaner. ClearDisk is free, open-so
 <details>
 <summary><strong>Does ClearDisk work on Intel Macs?</strong></summary>
 
-Currently ClearDisk requires macOS 14+ (Sonoma) on Apple Silicon. Intel Mac support may be added in a future release.
+Yes. ClearDisk requires macOS 14+ (Sonoma) and ships as a universal binary for both Apple Silicon and Intel Macs.
 </details>
 
 <details>

--- a/docs/blog/mac-disk-cleaner-comparison.html
+++ b/docs/blog/mac-disk-cleaner-comparison.html
@@ -362,7 +362,7 @@
                 <li>Detects 15+ developer cache types (Xcode, npm, Docker, pip, CocoaPods, Cargo, SPM, Homebrew, etc.)</li>
                 <li>Shows real-time sizes before you clean anything</li>
                 <li>Install via Homebrew: <code>brew tap bysiber/cleardisk && brew install --cask cleardisk</code></li>
-                <li>Lightweight (~6 MB universal)</li>
+                <li>Lightweight (~590 KB)</li>
             </ul>
 
             <p><strong class="cons">Cons:</strong></p>

--- a/docs/blog/mac-disk-cleaner-comparison.html
+++ b/docs/blog/mac-disk-cleaner-comparison.html
@@ -362,7 +362,7 @@
                 <li>Detects 15+ developer cache types (Xcode, npm, Docker, pip, CocoaPods, Cargo, SPM, Homebrew, etc.)</li>
                 <li>Shows real-time sizes before you clean anything</li>
                 <li>Install via Homebrew: <code>brew tap bysiber/cleardisk && brew install --cask cleardisk</code></li>
-                <li>Lightweight (~590 KB)</li>
+                <li>Lightweight (~6 MB universal)</li>
             </ul>
 
             <p><strong class="cons">Cons:</strong></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -296,7 +296,7 @@
 
     <section class="stats">
         <div class="stat">
-            <div class="number">~6 MB</div>
+            <div class="number">590 KB</div>
             <div class="label">App Size</div>
         </div>
         <div class="stat">
@@ -417,7 +417,7 @@
                 </tr>
                 <tr>
                     <td>App Size</td>
-                    <td>~6 MB</td>
+                    <td>590 KB</td>
                     <td>~100 MB</td>
                     <td>~25 MB</td>
                     <td>~5 MB</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -296,7 +296,7 @@
 
     <section class="stats">
         <div class="stat">
-            <div class="number">590 KB</div>
+            <div class="number">~6 MB</div>
             <div class="label">App Size</div>
         </div>
         <div class="stat">
@@ -417,7 +417,7 @@
                 </tr>
                 <tr>
                     <td>App Size</td>
-                    <td>590 KB</td>
+                    <td>~6 MB</td>
                     <td>~100 MB</td>
                     <td>~25 MB</td>
                     <td>~5 MB</td>

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Build ClearDisk.app bundle
-set -e
+# Build ClearDisk.app bundle (universal: arm64 + x86_64)
+set -euo pipefail
 
 APP_NAME="ClearDisk"
 
@@ -8,25 +8,84 @@ APP_NAME="ClearDisk"
 # THE version. Bump it here and nowhere else: it is baked into Info.plist below,
 # and the app reads it back at runtime (see AppInfo in ClearDiskApp.swift), so the
 # UI, the About box and the bundle can never drift apart.
-VERSION="1.8.1"
-BUILD_NUMBER="20"
+VERSION="1.8.2"
+BUILD_NUMBER="21"
 # ---------------------------------------------------------------------------
+
+# Architectures for the release binary. One DMG runs on Apple Silicon and Intel.
+# Override for a faster host-only build: ARCHES=arm64 ./scripts/build_app.sh
+ARCHES=(${ARCHES:-arm64 x86_64})
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUILD_DIR="$(dirname "$SCRIPT_DIR")"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
+MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
+BINARY_OUT="$MACOS_DIR/$APP_NAME"
 
-echo "Building $APP_NAME..."
+triple_for_arch() {
+    printf '%s-apple-macosx' "$1"
+}
+
+binary_path_for_arch() {
+    local arch="$1"
+    printf '%s/.build/%s/release/%s' "$BUILD_DIR" "$(triple_for_arch "$arch")" "$APP_NAME"
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "error: '$1' is required but not installed." >&2
+        exit 1
+    }
+}
+
+assert_universal() {
+    local info
+    info="$(lipo -info "$BINARY_OUT")"
+    echo "$info"
+    echo "$info" | grep -q 'arm64' || {
+        echo "error: fat binary missing arm64 slice: $info" >&2
+        exit 1
+    }
+    echo "$info" | grep -q 'x86_64' || {
+        echo "error: fat binary missing x86_64 slice: $info" >&2
+        exit 1
+    }
+}
+
+require_cmd swift
+require_cmd lipo
+require_cmd codesign
+require_cmd file
+
+echo "Building $APP_NAME (${ARCHES[*]})..."
 cd "$BUILD_DIR"
-swift build -c release 2>&1
+
+BUILT_BINS=()
+for arch in "${ARCHES[@]}"; do
+    triple="$(triple_for_arch "$arch")"
+    echo "  -> swift build -c release --triple $triple"
+    swift build -c release --triple "$triple" 2>&1
+    bin="$(binary_path_for_arch "$arch")"
+    if [ ! -f "$bin" ]; then
+        echo "error: expected binary missing after $arch build: $bin" >&2
+        exit 1
+    fi
+    BUILT_BINS+=("$bin")
+done
 
 echo "Creating app bundle..."
 rm -rf "$APP_BUNDLE"
-mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$MACOS_DIR"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 
-# Copy binary
-cp ".build/release/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+if [ "${#BUILT_BINS[@]}" -eq 1 ]; then
+    cp "${BUILT_BINS[0]}" "$BINARY_OUT"
+else
+    lipo -create "${BUILT_BINS[@]}" -output "$BINARY_OUT"
+    assert_universal
+fi
+
+file "$BINARY_OUT"
 
 # Copy app icon
 if [ -f "Resources/AppIcon.icns" ]; then
@@ -76,4 +135,4 @@ echo "Code signed (ad-hoc)."
 
 echo "Done! App bundle created at: $APP_BUNDLE"
 echo "To run: open $APP_BUNDLE"
-ls -la "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+ls -la "$BINARY_OUT"

--- a/scripts/do_dmg.sh
+++ b/scripts/do_dmg.sh
@@ -32,10 +32,18 @@ elif [ "$VERSION" != "$DECLARED" ]; then
 fi
 
 info "Building $APP_NAME $VERSION (release)"
-"$SCRIPTS_DIR/build_app.sh" >/dev/null
+# Keep build_app stdout visible — it asserts universal slices and prints lipo/file output.
+"$SCRIPTS_DIR/build_app.sh"
 
 APP="$ROOT_DIR/$APP_NAME.app"
 [ -d "$APP" ] || die "$APP was not produced by build_app.sh"
+
+BIN="$APP/Contents/MacOS/$APP_NAME"
+[ -f "$BIN" ] || die "Missing executable: $BIN"
+LIPO_INFO="$(lipo -info "$BIN" 2>/dev/null || true)"
+echo "$LIPO_INFO" | grep -q 'arm64'  || die "Release binary is not universal (missing arm64): $LIPO_INFO"
+echo "$LIPO_INFO" | grep -q 'x86_64' || die "Release binary is not universal (missing x86_64): $LIPO_INFO"
+ok "universal binary: $LIPO_INFO"
 
 # The DMG filename is baked into the Homebrew cask URL, so a stale bundle would ship under the
 # wrong name and every `brew install` would fetch the wrong build. Catch that here, not later.

--- a/scripts/do_dmg.sh
+++ b/scripts/do_dmg.sh
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   ./scripts/do_dmg.sh                  # version comes from CHANGELOG.md
-#   ./scripts/do_dmg.sh --version 1.8.0  # only to double-check; must match CHANGELOG.md
+#   ./scripts/do_dmg.sh --version 1.8.3  # only to double-check; must match CHANGELOG.md
 #
 # Writes the DMG plus a <dmg>.sha256 sidecar that brew_update.sh picks up automatically.
 


### PR DESCRIPTION
## Summary
- Ship a universal (`arm64` + `x86_64`) release binary so one DMG / `.app` runs on both Apple Silicon and Intel Macs (macOS 14+).
- Harden packaging: `build_app.sh` builds via `--triple` and asserts both lipo slices; `do_dmg.sh` re-checks before creating the DMG.
- Update docs/site/FAQ for Intel support and correct advertised app size (~6 MB, was outdated at 590 KB). Version bumped to **1.8.2**.

## Test plan
- [x] `bash scripts/build_app.sh` succeeds on this machine
- [x] `lipo -info ClearDisk.app/Contents/MacOS/ClearDisk` shows both `x86_64` and `arm64`
- [x] `open ClearDisk.app` — menu bar icon appears and UI works on Intel Mac
- [x] `bash scripts/do_dmg.sh` succeeds and prints the universal-binary ok line
- [x] Mount `dist/ClearDisk-v1.8.2.dmg`, install/open app, confirm it launches
- [x] (Optional) Smoke-build on Apple Silicon and confirm the same fat binary