### PR TITLE
fix: stop offering Claude session data as a deletable cache (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to ClearDisk are documented here.
 
 ## [1.8.3] - Unreleased
+### Fixed
+- **Claude Code and Claude Desktop data was offered up as a deletable cache** (#27). Both entries were marked 🟡 caution and described as regenerable — "Re-creates on next session". They are not. `~/.claude` and `~/Library/Application Support/Claude` hold session transcripts, job state, file history, plugins and user settings; on a normal machine over 99% of `~/.claude` is data that nothing brings back. A user lost their entire Claude CoWork session history this way. Both are now 🔴 risky, alongside Docker, and their descriptions say plainly that deleting them is permanent.
+- **"Clean Safe Caches" swept 🟡 caution caches too.** It filtered on "not risky", so one click also emptied Xcode Archives — including the dSYMs needed to symbolicate released crash reports — along with Android emulators, Cursor and Windsurf workspace state, and every language-version manager (nvm, pyenv, rbenv, mise, RVM). Caution entries are now excluded from the bulk action and must be selected deliberately.
+
 ### Changed
 - Universal binary for Apple Silicon and Intel (`arm64` + `x86_64` via `lipo`)
 

--- a/Sources/ClearDisk/DiskMonitor.swift
+++ b/Sources/ClearDisk/DiskMonitor.swift
@@ -187,7 +187,7 @@ class DiskMonitor: ObservableObject {
     
     private func calculateCleanable() {
         let devTotal = devCaches.reduce(Int64(0)) { $0 + $1.size }
-        let safeDevTotal = devCaches.filter { $0.riskLevel != "risky" }.reduce(Int64(0)) { $0 + $1.size }
+        let safeDevTotal = devCaches.filter { $0.riskLevel == "safe" }.reduce(Int64(0)) { $0 + $1.size }
         let riskyDevTotal = devCaches.filter { $0.riskLevel == "risky" }.reduce(Int64(0)) { $0 + $1.size }
         let trashTotal = trashSize()
         totalCleanable = devTotal + trashTotal
@@ -421,8 +421,8 @@ class DiskMonitor: ObservableObject {
         "RVM": "RVM rubies and gemsets. Reinstall with rvm install X.Y.Z.",
         "Bundler Cache": "Downloaded gem files. Rebuilds automatically with bundle install.",
         // AI Tools
-        "Claude Desktop": "Claude Desktop conversation cache and temp files. Can grow very large. Re-downloads on next launch.",
-        "Claude Code": "Claude Code CLI session history and configs. Re-creates on next session.",
+        "Claude Desktop": "Claude Desktop and Claude CoWork store session state here. Deleting this is permanent — local sessions are not backed up to a server and do not come back.",
+        "Claude Code": "Session transcripts, job state, file history, plugins and your settings. Almost none of this is a cache — deleting it permanently loses your Claude Code history.",
         "HuggingFace Cache": "Downloaded AI/ML models, tokenizers, and datasets. Re-downloads on next use. Large models may take time.",
         "Ollama Models": "Downloaded LLM model files. Re-downloads with ollama pull.",
         "ChatGPT Desktop": "ChatGPT Desktop app data. Conversations sync to cloud.",
@@ -569,8 +569,15 @@ class DiskMonitor: ObservableObject {
             ("VS Code Chromium Cache", "laptopcomputer", "\(home)/Library/Application Support/Code/Cache", "safe", "VS Code"),
             ("VS Code Logs", "laptopcomputer", "\(home)/Library/Application Support/Code/logs", "safe", "VS Code"),
             // AI Tools
-            ("Claude Desktop", "bubble.left.fill", "\(home)/Library/Application Support/Claude", "caution", "AI Tools"),
-            ("Claude Code", "terminal.fill", "\(home)/.claude", "caution", "AI Tools"),
+            // Both Claude entries are "risky", not "caution". They were "caution" until #27, where a
+            // user lost every Claude CoWork session with no way back. These are not caches: on a
+            // normal machine over 99% of ~/.claude is session transcripts, job state, file history,
+            // plugins and settings, and none of it regenerates. Splitting out the few genuinely
+            // disposable subdirectories was considered and rejected — it recovers about 1 MB, while
+            // names lie (`paste-cache` holds content the user pasted, referenced by transcripts).
+            // If you are tempted to narrow these paths, verify what is inside first.
+            ("Claude Desktop", "bubble.left.fill", "\(home)/Library/Application Support/Claude", "risky", "AI Tools"),
+            ("Claude Code", "terminal.fill", "\(home)/.claude", "risky", "AI Tools"),
             ("HuggingFace Cache", "brain.head.profile", "\(home)/.cache/huggingface", "caution", "AI Tools"),
             ("Ollama Models", "brain", "\(home)/.ollama/models", "risky", "AI Tools"),
             ("ChatGPT Desktop", "bubble.right.fill", "\(home)/Library/Group Containers/group.com.openai.chat", "caution", "AI Tools"),
@@ -812,9 +819,15 @@ class DiskMonitor: ObservableObject {
         }
     }
 
-    /// Clean only safe caches (excludes risky caches like Docker)
+    /// Clean only the caches marked 🟢 safe — never 🟡 caution, never 🔴 risky.
+    ///
+    /// This used to sweep everything that was not "risky", which put caution entries behind a
+    /// button labelled "Clean Safe Caches": Xcode Archives (the dSYMs you need to symbolicate
+    /// released crash reports), Android AVDs, Cursor and Windsurf workspace state, and the
+    /// language-version managers. One click, and none of it comes back on its own. Caution
+    /// entries now require the user to pick them deliberately, one at a time.
     func cleanSafeCaches() {
-        cleanCaches(devCaches.filter { $0.riskLevel != "risky" }, title: "Safe caches")
+        cleanCaches(devCaches.filter { $0.riskLevel == "safe" }, title: "Safe caches")
     }
 
     /// Clean ALL caches including risky ones (requires explicit user confirmation)

--- a/Sources/ClearDisk/MainView.swift
+++ b/Sources/ClearDisk/MainView.swift
@@ -129,17 +129,17 @@ struct MainView: View {
             Button("Cancel", role: .cancel) { }
             Button("Move to Trash", role: .destructive) {
                 isCleaning = true
-                diskMonitor.devCaches.removeAll { $0.riskLevel != "risky" }
+                diskMonitor.devCaches.removeAll { $0.riskLevel == "safe" }
                 diskMonitor.cleanSafeCaches()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) { isCleaning = false }
             }
         } message: {
-            let safeCaches = diskMonitor.devCaches.filter { $0.riskLevel != "risky" }
+            let safeCaches = diskMonitor.devCaches.filter { $0.riskLevel == "safe" }
             let safeTotal = safeCaches.reduce(Int64(0)) { $0 + $1.size }
             let xcodeWarning = diskMonitor.isXcodeRunning()
                 ? "\n\n⚠️ Xcode is currently running! Close Xcode first for best results."
                 : ""
-            Text("Clean \(safeCaches.count) safe/caution caches?\nThis will move \(formatBytes(safeTotal)) to Trash.\n\nRisky caches (like Docker) are NOT included.\nFiles go to Trash — you can recover them.\(xcodeWarning)")
+            Text("Clean \(safeCaches.count) safe caches?\nThis will move \(formatBytes(safeTotal)) to Trash.\n\n🟡 Caution and 🔴 risky caches are NOT included — select those individually.\nFiles go to Trash — you can recover them.\(xcodeWarning)")
         }
         .alert("Clean ALL Developer Caches", isPresented: $showCleanAllConfirm) {
             Button("Cancel", role: .cancel) { }
@@ -416,11 +416,12 @@ struct MainView: View {
     
     // MARK: - Cleanable Summary (Hero Card)
     var cleanableSummary: some View {
-        let safeDevTotal = diskMonitor.devCaches.filter { $0.riskLevel != "risky" }.reduce(Int64(0)) { $0 + $1.size }
+        let safeDevTotal = diskMonitor.devCaches.filter { $0.riskLevel == "safe" }.reduce(Int64(0)) { $0 + $1.size }
+        let cautionDevTotal = diskMonitor.devCaches.filter { $0.riskLevel == "caution" }.reduce(Int64(0)) { $0 + $1.size }
         let riskyDevTotal = diskMonitor.devCaches.filter { $0.riskLevel == "risky" }.reduce(Int64(0)) { $0 + $1.size }
         let artifactTotal = diskMonitor.projectArtifacts.reduce(Int64(0)) { $0 + $1.size }
         let trashTotal = diskMonitor.trashSize()
-        let grandTotal = safeDevTotal + riskyDevTotal + artifactTotal + trashTotal
+        let grandTotal = safeDevTotal + cautionDevTotal + riskyDevTotal + artifactTotal + trashTotal
         
         return VStack(spacing: 8) {
             // Big total number


### PR DESCRIPTION
Fixes #27.

Two entries pointed at `~/.claude` and `~/Library/Application Support/Claude` in their entirety, marked them caution, and described them as regenerable: "Re-creates on next session". They are not. Those directories hold session transcripts, job state, file history, plugins and settings. On a normal machine roughly 373 MB of the 374 MB in `~/.claude` is data that nothing brings back.

Caution was never a barrier either. cleanSafeCaches() filtered on "not risky", so the button labelled Clean Safe Caches emptied every caution entry too. One click, and with the app own Empty Trash the loss became permanent. That is what cost the reporter their Claude CoWork session history.

Both entries are now risky, alongside Docker. They are excluded from the bulk action, hidden from the Moderate view, and named in the red warning if selected in Everything mode. Their descriptions say the deletion is permanent.

Narrowing the paths to the genuinely disposable subdirectories was considered and rejected. It recovers about 1 MB, and the names cannot be trusted to say what is disposable: `~/.claude/paste-cache` holds content the user pasted, which transcripts refer back to. Guessing from directory names is what caused this in the first place.

The filter change reaches further than Claude. Clean Safe Caches also used to empty Xcode Archives, including the dSYMs needed to symbolicate released crash reports, along with Android emulators, Cursor and Windsurf workspace state, and every language-version manager. Those now require deliberate selection.