### PR TITLE
fix: set AI tool risk levels by what deletion costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to ClearDisk are documented here.
 
+## [1.8.4] - Unreleased
+### Changed
+- **AI tool risk levels now follow what deleting actually costs, not which app owns the directory.** 🟢 safe means it comes back on its own, 🟡 caution means it comes back but costs time or bandwidth, 🔴 risky means this is the only copy of something you made.
+  - `Cursor` and `Windsurf` (renamed from "Cursor Cache" / "Windsurf Cache") are now 🔴 risky. Both entries cover the whole `~/Library/Application Support/<app>` directory, which for an AI editor holds chat history, workspace state and settings — the same shape as the Claude entries in #27, and they still claimed to "re-build on next launch".
+  - `Ollama Models` moves from 🔴 risky to 🟡 caution. Model files are downloads, not user work; `ollama pull` brings them back. They are also often the largest entry in the list, and risky was hiding them from the Moderate view.
+
 ## [1.8.3] - 2026-08-01
 ### Fixed
 - **Claude Code and Claude Desktop data was offered up as a deletable cache** (#27). Both entries were marked 🟡 caution and described as regenerable — "Re-creates on next session". They are not. `~/.claude` and `~/Library/Application Support/Claude` hold session transcripts, job state, file history, plugins and user settings; on a normal machine over 99% of `~/.claude` is data that nothing brings back. A user lost their entire Claude CoWork session history this way. Both are now 🔴 risky, alongside Docker, and their descriptions say plainly that deleting them is permanent.

--- a/Sources/ClearDisk/DiskMonitor.swift
+++ b/Sources/ClearDisk/DiskMonitor.swift
@@ -424,10 +424,10 @@ class DiskMonitor: ObservableObject {
         "Claude Desktop": "Claude Desktop and Claude CoWork store session state here. Deleting this is permanent — local sessions are not backed up to a server and do not come back.",
         "Claude Code": "Session transcripts, job state, file history, plugins and your settings. Almost none of this is a cache — deleting it permanently loses your Claude Code history.",
         "HuggingFace Cache": "Downloaded AI/ML models, tokenizers, and datasets. Re-downloads on next use. Large models may take time.",
-        "Ollama Models": "Downloaded LLM model files. Re-downloads with ollama pull.",
+        "Ollama Models": "Downloaded LLM model files. Re-downloads with ollama pull — large models take a while.",
         "ChatGPT Desktop": "ChatGPT Desktop app data. Conversations sync to cloud.",
-        "Cursor Cache": "Cursor editor cache, workspace storage, and extensions data. Re-builds on next launch.",
-        "Windsurf Cache": "Windsurf editor cache and workspace data. Re-builds on next launch.",
+        "Cursor": "Cursor's whole application-support directory: workspace state, chat history, extensions and settings. Not a cache — deleting it is permanent.",
+        "Windsurf": "Windsurf's whole application-support directory: workspace state, chat history and settings. Not a cache — deleting it is permanent.",
         // Game Engines
         "Unity Asset Store": "Unity Asset Store downloaded packages. Re-downloads from Unity Package Manager.",
         "UnityHub Templates": "Unity project starter templates downloaded by Unity Hub. Re-download from Hub when needed. Can be 300MB+.",
@@ -579,10 +579,16 @@ class DiskMonitor: ObservableObject {
             ("Claude Desktop", "bubble.left.fill", "\(home)/Library/Application Support/Claude", "risky", "AI Tools"),
             ("Claude Code", "terminal.fill", "\(home)/.claude", "risky", "AI Tools"),
             ("HuggingFace Cache", "brain.head.profile", "\(home)/.cache/huggingface", "caution", "AI Tools"),
-            ("Ollama Models", "brain", "\(home)/.ollama/models", "risky", "AI Tools"),
+            // Caution, not risky: these are downloads, not something the user made. `ollama pull`
+            // brings them back, so the cost of deleting is bandwidth and time, not loss. They are
+            // also often the largest thing in this list, and risky hides them from the Moderate view.
+            ("Ollama Models", "brain", "\(home)/.ollama/models", "caution", "AI Tools"),
             ("ChatGPT Desktop", "bubble.right.fill", "\(home)/Library/Group Containers/group.com.openai.chat", "caution", "AI Tools"),
-            ("Cursor Cache", "cursorarrow.rays", "\(home)/Library/Application Support/Cursor", "caution", "AI Tools"),
-            ("Windsurf Cache", "wind", "\(home)/Library/Application Support/Windsurf", "caution", "AI Tools"),
+            // Same shape as the two Claude entries: a whole ~/Library/Application Support/<app>
+            // directory, which for an AI editor is where the chat history and workspace state live.
+            // Calling it a "Cache" and marking it caution is what made #27 possible.
+            ("Cursor", "cursorarrow.rays", "\(home)/Library/Application Support/Cursor", "risky", "AI Tools"),
+            ("Windsurf", "wind", "\(home)/Library/Application Support/Windsurf", "risky", "AI Tools"),
             // Game Engines
             ("Unity Asset Store", "gamecontroller.fill", "\(home)/Library/Unity/Asset Store-5.x", "caution", "Game Engines"),
             ("UnityHub Templates", "square.and.arrow.down.fill", "\(home)/Library/Application Support/UnityHub/Templates", "caution", "Game Engines"),


### PR DESCRIPTION
Follow-up to #29. That one fixed the two Claude entries after someone lost data. This applies the same reasoning to the rest of the AI Tools group, before anyone else runs into it.

The rule: a risk level describes what happens when you delete a path, not which app owns it. Safe means it comes back on its own. Caution means it comes back but costs time or bandwidth. Risky means this is the only copy of something the user made.

Cursor and Windsurf become risky, and lose "Cache" from their names. Both entries cover the whole `~/Library/Application Support/<app>` directory, which for an AI editor is where chat history, workspace state and settings live. They were marked caution and described as "Re-builds on next launch", which is the same mistake as #27.

Ollama Models becomes caution. Model files are downloads rather than something the user made, and `ollama pull` brings them back, so the cost is bandwidth and time, not loss. It is also often the largest entry in the list, and risky was hiding it from the Moderate view.

HuggingFace stays caution for the same reason. ChatGPT Desktop stays caution because its conversations live on OpenAI servers, so the local copy is not the only one.

Risky entries are still listed under the collapsible AI Tools group and can be expanded and picked individually. What changes is that they are excluded from Clean Safe Caches and named in the red warning when selected.