### PR TITLE
feat: add an appearance setting for dark, light or system (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ ClearDisk scans **74 developer cache paths** in one tool. Lives in your menu bar
 - **Xcode Running Check** — Warns you if Xcode is running when you try to clean Xcode-related caches
 - **Safe Delete** — Files go to Trash, not permanent delete. You can always recover
 - **Visual Category Bars** — Color-coded proportional bars showing what's eating your disk
+- **Appearance** — Dark, Light, or System (the default) in Settings
 - **Recovery Tracking** — "Recovered 12.4 GB!" banner after cleanup + cumulative "Total saved: 123 GB" counter
 - **Storage Forecast** — Predicts when your disk will be full based on usage trends (linear regression, 90-day history)
 - **Smart Suggestions** — Age-based recommendations ("Not used for 90 days — safe to clean")

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ ClearDisk scans **74 developer cache paths** in one tool. Lives in your menu bar
 - **Xcode Running Check** — Warns you if Xcode is running when you try to clean Xcode-related caches
 - **Safe Delete** — Files go to Trash first and remain recoverable until Trash is emptied
 - **Visual Category Bars** — Color-coded proportional bars showing what's eating your disk
+- **Appearance** — Follow the system theme or use Light or Dark across ClearDisk's windows and panels
 - **Cleanup Tracking** — distinguishes bytes moved to Trash from space actually reclaimed after Trash is emptied
 - **Storage Forecast** — Predicts when your disk will be full based on usage trends (linear regression, 90-day history)
 - **Smart Suggestions** — Age-based recommendations ("Not used for 90 days — safe to clean")

--- a/Sources/ClearDisk/AppAppearance.swift
+++ b/Sources/ClearDisk/AppAppearance.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+enum AppAppearance: String, CaseIterable, Identifiable {
+    static let storageKey = "appearance"
+
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system: return "System"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}

--- a/Sources/ClearDisk/DiskSpaceWindow.swift
+++ b/Sources/ClearDisk/DiskSpaceWindow.swift
@@ -898,6 +898,7 @@ final class DiskSpaceWindowController: NSObject, NSWindowDelegate {
 private struct DiskSpaceRootView: View {
     @ObservedObject var store: DiskSpaceStore
     @ObservedObject var diskMonitor: DiskMonitor
+    @AppStorage(AppAppearance.storageKey) private var appearance: AppAppearance = .system
 
     private var selection: Binding<String?> {
         Binding(
@@ -931,6 +932,7 @@ private struct DiskSpaceRootView: View {
                 .navigationTitle("Disk Space")
         }
         .frame(minWidth: 820, minHeight: 560)
+        .preferredColorScheme(appearance.colorScheme)
     }
 }
 

--- a/Sources/ClearDisk/MainView.swift
+++ b/Sources/ClearDisk/MainView.swift
@@ -42,6 +42,7 @@ struct MainView: View {
     @State private var showDeleteFileConfirm = false
     @State private var expandedLargeFileFolder: String? = nil
     @AppStorage("launchAtLogin") private var launchAtLogin = true
+    @AppStorage("appearance") private var appearance: Appearance = .system
 
     
     enum Tab: String, CaseIterable {
@@ -74,6 +75,22 @@ struct MainView: View {
         case all = "All"
         case stale = "Stale (>30d)"
     }
+
+    enum Appearance: String, CaseIterable, Identifiable {
+        case dark, light, system
+
+        var id: String { rawValue }
+        var label: String { rawValue.capitalized }
+
+        /// nil follows macOS, and keeps following it when the system setting changes.
+        var colorScheme: ColorScheme? {
+            switch self {
+            case .dark: return .dark
+            case .light: return .light
+            case .system: return nil
+            }
+        }
+    }
     
     var body: some View {
         Group {
@@ -89,6 +106,8 @@ struct MainView: View {
             }
         }
         .frame(width: Layout.popoverWidth, height: Layout.popoverHeight)
+        // Themes the whole popover, not just this tree: SwiftUI applies it to the hosting window.
+        .preferredColorScheme(appearance.colorScheme)
         .overlay {
             if let sheet = activeProjectSheet {
                 projectSheetOverlay(sheet)
@@ -1670,6 +1689,25 @@ struct MainView: View {
                     .background(Color.primary.opacity(0.03))
                     .cornerRadius(8)
                     
+                    // Appearance section
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Appearance", systemImage: "circle.lefthalf.filled")
+                            .font(.system(size: 13, weight: .semibold))
+
+                        Picker("Appearance", selection: $appearance) {
+                            ForEach(Appearance.allCases) { option in
+                                Text(option.label).tag(option)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                        .controlSize(.small)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(Color.primary.opacity(0.03))
+                    .cornerRadius(8)
+
                     // About section
                     VStack(alignment: .leading, spacing: 10) {
                         Label("About", systemImage: "info.circle.fill")

--- a/Sources/ClearDisk/MainView.swift
+++ b/Sources/ClearDisk/MainView.swift
@@ -50,6 +50,7 @@ struct MainView: View {
     @State private var showDeleteFileConfirm = false
     @State private var expandedLargeFileFolder: String? = nil
     @AppStorage("launchAtLogin") private var launchAtLogin = true
+    @AppStorage(AppAppearance.storageKey) private var appearance: AppAppearance = .system
     @AppStorage("primaryMode") private var primaryMode: PrimaryMode = .cleaner
     @AppStorage("cacheSafetyBannerDismissed") private var cacheSafetyBannerDismissed = false
     
@@ -242,6 +243,7 @@ struct MainView: View {
                  ? "\(failure.title) is still on disk — nothing was deleted.\n\n\(failure.reason)\n\nClearDisk needs Full Disk Access to move files to the Trash. Grant it in System Settings → Privacy & Security → Full Disk Access, then quit and reopen ClearDisk."
                  : "\(failure.title) is still on disk — nothing was deleted.\n\n\(failure.reason)")
         }
+        .preferredColorScheme(appearance.colorScheme)
     }
     
     /// The project sheets are drawn INSIDE the popover instead of with `.sheet`.
@@ -2448,6 +2450,29 @@ struct MainView: View {
                                 print("Failed to update login item: \(error)")
                             }
                         }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+                    .background(Color.primary.opacity(0.03))
+                    .cornerRadius(8)
+
+                    // Appearance section
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Appearance", systemImage: "circle.lefthalf.filled")
+                            .font(.system(size: 13, weight: .semibold))
+
+                        Text("Choose how ClearDisk windows and panels appear.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+
+                        Picker("Appearance", selection: $appearance) {
+                            ForEach(AppAppearance.allCases) { option in
+                                Text(option.title).tag(option)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                        .controlSize(.small)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(12)

--- a/Sources/ClearDisk/PrimaryModePanel.swift
+++ b/Sources/ClearDisk/PrimaryModePanel.swift
@@ -43,6 +43,7 @@ private struct PrimaryModePanelView: View {
     @ObservedObject var diskMonitor: DiskMonitor
     @ObservedObject var panelState: PrimaryModePanelState
     @AppStorage("primaryMode") private var primaryMode: PrimaryMode = .cleaner
+    @AppStorage(AppAppearance.storageKey) private var appearance: AppAppearance = .system
     @State private var hoveredMode: PrimaryMode?
 
     let onHoverChanged: (Bool) -> Void
@@ -180,6 +181,7 @@ private struct PrimaryModePanelView: View {
             height: PrimaryModePanelController.panelHeight,
             alignment: .trailing
         )
+        .preferredColorScheme(appearance.colorScheme)
     }
 }
 


### PR DESCRIPTION
Closes #33.

## What changed

- Adds a persisted System / Light / Dark appearance preference in Settings.
- Uses one shared `AppAppearance` model and storage key.
- Applies the preference to the main popover, attached primary-mode panel, and Disk Space window.
- Keeps System as the default and leaves the macOS menu bar status item under system appearance.
- Updates the original implementation for the current multi-window ClearDisk architecture.

The contributor branch has been updated with the current `main`.

## Verification

- Clean `swift build` against current `main`
- Combined local integration app built, signed ad-hoc, installed, and launched successfully