### PR TITLE
Improve cleanup safety and scan scheduling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,11 @@ let package = Package(
         .executableTarget(
             name: "ClearDisk",
             path: "Sources/ClearDisk"
+        ),
+        .testTarget(
+            name: "ClearDiskTests",
+            dependencies: ["ClearDisk"],
+            path: "Tests/ClearDiskTests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ ClearDisk scans **74 developer cache paths** in one tool. Lives in your menu bar
 - **Menu Bar Monitor** — Always-on disk usage display. Changes color at 80%/90% thresholds. Shows cleanable amount when disk is stressed
 - **Risk Levels** — 🟢 Safe (rebuilds with a command), 🟡 Caution (large re-download needed), 🔴 Risky (may contain irreplaceable data)
 - **Xcode Running Check** — Warns you if Xcode is running when you try to clean Xcode-related caches
-- **Safe Delete** — Files go to Trash, not permanent delete. You can always recover
+- **Safe Delete** — Files go to Trash first and remain recoverable until Trash is emptied
 - **Visual Category Bars** — Color-coded proportional bars showing what's eating your disk
-- **Recovery Tracking** — "Recovered 12.4 GB!" banner after cleanup + cumulative "Total saved: 123 GB" counter
+- **Cleanup Tracking** — distinguishes bytes moved to Trash from space actually reclaimed after Trash is emptied
 - **Storage Forecast** — Predicts when your disk will be full based on usage trends (linear regression, 90-day history)
 - **Smart Suggestions** — Age-based recommendations ("Not used for 90 days — safe to clean")
 - **Smart Notifications** — Alerts at 80% and 90% disk usage, no spam
@@ -113,7 +113,7 @@ Requires macOS 14+ (Apple Silicon and Intel). Release builds are universal (`arm
 
 ## How It Works
 
-ClearDisk scans **known developer cache directories** on a 5-minute interval:
+ClearDisk refreshes free disk capacity every 5 minutes and scans **known developer cache directories** every 30 minutes:
 
 ```
 ~/Library/Developer/Xcode/DerivedData           → 🟢 Safe
@@ -154,7 +154,7 @@ When you clean, files are **moved to Trash** (not permanently deleted). You can 
 
 - **Zero network access** — the app never connects to the internet
 - **Zero telemetry** — no analytics, no crash reports, no usage data
-- **Zero background processes** — only scans when the popover is open or on a 5-min timer
+- **Zero helper processes** — the menu-bar app checks capacity every 5 minutes and scans when the popover opens or every 30 minutes while running
 - **Open source** — read every line of code yourself
 - **Safe delete** — everything goes to Trash first
 

--- a/Sources/ClearDisk/ClearDiskApp.swift
+++ b/Sources/ClearDisk/ClearDiskApp.swift
@@ -58,7 +58,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         diskMonitor = DiskMonitor()
         diskMonitor.setupNotifications()
-        diskMonitor.loadSavedTotal()
+        diskMonitor.loadCleanupTotals()
         
         // Create status bar item
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -89,9 +89,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             }
             .store(in: &cancellables)
         
-        // Refresh periodically (5 min)
-        Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
-            self?.diskMonitor.scan()
+        // One timer avoids a light refresh and a full scan racing each other at the 30-minute mark.
+        // Five ticks perform only a cheap APFS capacity lookup; every sixth tick refreshes all
+        // results. The full scan also refreshes capacity, so no separate lookup is needed then.
+        var refreshTick = 0
+        Timer.scheduledTimer(withTimeInterval: 5 * 60, repeats: true) { [weak self] _ in
+            refreshTick += 1
+            if refreshTick == 6 {
+                refreshTick = 0
+                self?.diskMonitor.scan()
+            } else {
+                self?.diskMonitor.refreshDiskSpaceOnly()
+            }
         }
     }
     

--- a/Sources/ClearDisk/DiskMonitor.swift
+++ b/Sources/ClearDisk/DiskMonitor.swift
@@ -12,19 +12,23 @@ class DiskMonitor: ObservableObject {
     @Published var devCaches: [DevCache] = []
     @Published var largeFiles: [LargeFile] = []
     @Published var projectArtifacts: [ProjectArtifact] = [] // stale node_modules, target/, build/ etc.
+    @Published var trashSizeBytes: Int64 = 0
     @Published var isScanning: Bool = false
     @Published var totalCleanable: Int64 = 0
-    @Published var safeCleanable: Int64 = 0 // only safe + caution caches + trash
+    @Published var safeCleanable: Int64 = 0 // only explicitly safe caches + trash
     @Published var riskyCleanable: Int64 = 0 // risky caches (e.g. Docker data)
     @Published var forecastDaysUntilFull: Int? = nil // nil = not enough data
     @Published var dailyGrowthRate: Int64 = 0 // bytes per day
     @Published var usageHistory: [UsageSnapshot] = [] // for chart display
     
-    // Savings tracking
-    @Published var totalSavedAllTime: Int64 = 0 // cumulative bytes cleaned
-    @Published var lastCleanedAmount: Int64 = 0 // last cleanup size (for "Recovered X!" banner)
-    @Published var showRecoveredBanner: Bool = false // transient banner after cleanup
-    private let savedKey = "ClearDisk.totalSaved"
+    // Cleanup tracking. Moving an item to Trash does not reclaim disk space yet, so keep that
+    // distinct from permanently emptying Trash in both the model and the UI.
+    @Published var totalMovedToTrash: Int64 = 0
+    @Published var lastCleanedAmount: Int64 = 0
+    @Published var lastCleanOutcome: CleanOutcome = .movedToTrash
+    @Published var showCleanResultBanner: Bool = false
+    private let movedToTrashKey = "ClearDisk.totalMovedToTrash"
+    private let legacySavedKey = "ClearDisk.totalSaved"
     
     // Per-project cache cleanup history (persisted)
     @Published var projectCleanHistory: [ProjectCleanHistoryEntry] = []
@@ -36,12 +40,14 @@ class DiskMonitor: ObservableObject {
     @Published var inaccessiblePaths: [String] = [] // paths that couldn't be read
     @Published var hasCompletedFirstScan: Bool = false
 
-    /// Set when a clean could not free the space it promised, so the UI can say so.
-    /// Swallowing a failed trash is what let the app report "Recovered X!" while nothing moved.
+    /// Set when a clean could not move the bytes it promised, so the UI can say so.
+    /// Swallowing a failed trash is what previously let the app report success while nothing moved.
     @Published var cleanFailure: CleanFailure?
     
     // Track notification state to avoid spam
     private var lastNotifiedThreshold: Int = 0
+    private var isCapacityRefreshInProgress = false
+    private(set) var lastFullScanAt: Date?
     
     // Storage history key
     private let historyKey = "ClearDisk.usageHistory"
@@ -55,8 +61,16 @@ class DiskMonitor: ObservableObject {
         UserDefaults.standard.set(true, forKey: onboardingKey)
     }
     
-    func loadSavedTotal() {
-        totalSavedAllTime = Int64(UserDefaults.standard.integer(forKey: savedKey))
+    func loadCleanupTotals() {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: movedToTrashKey) != nil {
+            totalMovedToTrash = Int64(defaults.integer(forKey: movedToTrashKey))
+        } else {
+            // Versions before 1.9 called this value "saved", although those bytes had only been
+            // moved to Trash. Preserve the history while migrating it to the truthful label.
+            totalMovedToTrash = Int64(defaults.integer(forKey: legacySavedKey))
+            defaults.set(Int(totalMovedToTrash), forKey: movedToTrashKey)
+        }
         loadProjectCleanHistory()
     }
     
@@ -87,15 +101,18 @@ class DiskMonitor: ObservableObject {
         UserDefaults.standard.removeObject(forKey: projectHistoryKey)
     }
     
-    private func addToSavings(_ bytes: Int64) {
-        totalSavedAllTime += bytes
+    private func recordCleanResult(_ bytes: Int64, outcome: CleanOutcome) {
+        if outcome == .movedToTrash {
+            totalMovedToTrash += bytes
+            UserDefaults.standard.set(Int(totalMovedToTrash), forKey: movedToTrashKey)
+        }
         lastCleanedAmount = bytes
-        showRecoveredBanner = true
-        UserDefaults.standard.set(Int(totalSavedAllTime), forKey: savedKey)
+        lastCleanOutcome = outcome
+        showCleanResultBanner = true
         
         // Auto-hide banner after 5 seconds
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
-            self?.showRecoveredBanner = false
+            self?.showCleanResultBanner = false
         }
     }
     
@@ -156,10 +173,12 @@ class DiskMonitor: ObservableObject {
             // Reset scan status
             var inaccessible: [String] = []
             
-            self?.scanDiskSpace()
+            self?.scanDiskCapacity()
+            self?.scanDiskCategories()
             self?.scanDevCaches()
             self?.scanLargeFiles()
             self?.scanProjectArtifacts()
+            let trashBytes = self?.trashSize() ?? 0
             
             // Check which dev cache paths are inaccessible
             let devPaths = self?.devCachePaths() ?? []
@@ -176,6 +195,8 @@ class DiskMonitor: ObservableObject {
                 self?.isScanInProgress = false
                 self?.inaccessiblePaths = inaccessible
                 self?.hasCompletedFirstScan = true
+                self?.lastFullScanAt = Date()
+                self?.trashSizeBytes = trashBytes
                 self?.calculateCleanable()
                 self?.recordUsageSnapshot()
                 self?.calculateForecast()
@@ -184,12 +205,42 @@ class DiskMonitor: ObservableObject {
             }
         }
     }
+
+    /// Refreshes only APFS capacity values used by the menu-bar indicator. Unlike `scan()`, this
+    /// does not recursively enumerate the user's home folders, projects, caches, or large files.
+    func refreshDiskSpaceOnly() {
+        guard !isScanInProgress, !isCapacityRefreshInProgress else { return }
+        isCapacityRefreshInProgress = true
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            self?.scanDiskCapacity {
+                guard let self else { return }
+                self.isCapacityRefreshInProgress = false
+                self.recordUsageSnapshot()
+                self.calculateForecast()
+                self.checkThresholdNotification()
+            }
+        }
+    }
+
+    /// Opening the popover should feel fresh without turning every open/close into a recursive
+    /// filesystem crawl. A manual refresh still always calls `scan()` directly.
+    func scanIfStale(maxAge: TimeInterval = 30 * 60) {
+        guard let lastFullScanAt else {
+            scan()
+            return
+        }
+        if Date().timeIntervalSince(lastFullScanAt) >= maxAge {
+            scan()
+        } else {
+            refreshDiskSpaceOnly()
+        }
+    }
     
     private func calculateCleanable() {
         let devTotal = devCaches.reduce(Int64(0)) { $0 + $1.size }
         let safeDevTotal = devCaches.filter { $0.riskLevel == "safe" }.reduce(Int64(0)) { $0 + $1.size }
         let riskyDevTotal = devCaches.filter { $0.riskLevel == "risky" }.reduce(Int64(0)) { $0 + $1.size }
-        let trashTotal = trashSize()
+        let trashTotal = trashSizeBytes
         totalCleanable = devTotal + trashTotal
         safeCleanable = safeDevTotal + trashTotal
         riskyCleanable = riskyDevTotal
@@ -314,9 +365,7 @@ class DiskMonitor: ObservableObject {
     }
     
     // MARK: - Disk Space
-    private func scanDiskSpace() {
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        
+    private func scanDiskCapacity(completion: (() -> Void)? = nil) {
         do {
             let values = try URL(fileURLWithPath: "/").resourceValues(forKeys: [
                 .volumeTotalCapacityKey,
@@ -332,11 +381,17 @@ class DiskMonitor: ObservableObject {
                 self?.freeSpace = free
                 self?.usedSpace = used
                 self?.usedPercentage = total > 0 ? Int((Double(used) / Double(total)) * 100) : 0
+                completion?()
             }
         } catch {
             print("Error getting disk space: \(error)")
+            DispatchQueue.main.async { completion?() }
         }
-        
+    }
+
+    private func scanDiskCategories() {
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+
         // Scan categories
         let home = homeDir.path
         let categoryPaths: [(String, String, [String])] = [
@@ -513,7 +568,7 @@ class DiskMonitor: ObservableObject {
     /// Single source of truth for all developer cache paths
     /// (name, icon, path, riskLevel, group)
     /// Risk levels: safe = rebuild with command, caution = may need re-download, risky = data loss possible
-    private func allCachePaths() -> [(name: String, icon: String, path: String, riskLevel: String, group: String?)] {
+    func allCachePaths() -> [(name: String, icon: String, path: String, riskLevel: String, group: String?)] {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return [
             // Xcode & Apple
@@ -644,6 +699,14 @@ class DiskMonitor: ObservableObject {
     /// Returns list of (name, path) tuples for all known dev cache paths
     func devCachePaths() -> [(String, String)] {
         return allCachePaths().map { ($0.name, $0.path) }
+    }
+
+    static func isEligibleForSafeBulkClean(_ cache: DevCache) -> Bool {
+        cache.riskLevel == "safe"
+    }
+
+    static func requiresDataLossAcknowledgement(for caches: [DevCache]) -> Bool {
+        caches.contains { $0.riskLevel == "risky" }
     }
     
     private func scanDevCaches() {
@@ -796,10 +859,15 @@ class DiskMonitor: ObservableObject {
     }
 
     /// Records the outcome of a clean. Credits ONLY the bytes that actually reached the Trash and
-    /// surfaces the first failure, so a refused delete can never show up as "Recovered X!".
+    /// surfaces the first failure, so a refused delete can never show up as a successful move.
     /// Always re-scans: on failure the item is still on disk and must reappear in the list.
-    private func finishClean(title: String, freed: Int64, failure: String?) {
-        if freed > 0 { addToSavings(freed) }
+    private func finishClean(
+        title: String,
+        freed: Int64,
+        failure: String?,
+        outcome: CleanOutcome = .movedToTrash
+    ) {
+        if freed > 0 { recordCleanResult(freed, outcome: outcome) }
         if let failure {
             cleanFailure = CleanFailure(title: title, reason: failure, isPermission: Self.isPermissionError(failure))
         }
@@ -811,7 +879,7 @@ class DiskMonitor: ObservableObject {
         return r.contains("permission") || r.contains("not permitted") || r.contains("privileges")
     }
 
-    /// Move items to Trash instead of permanent delete — user can recover for 30 days.
+    /// Move items to Trash instead of permanent delete — user can recover until Trash is emptied.
     /// NEVER falls back to permanent delete. If trash fails, it fails safely.
     /// Returns `nil` on success, or a human-readable reason on failure.
     private func moveToTrash(path: String) -> String? {
@@ -856,20 +924,10 @@ class DiskMonitor: ObservableObject {
         }
     }
 
-    /// Clean only the caches marked 🟢 safe — never 🟡 caution, never 🔴 risky.
-    ///
-    /// This used to sweep everything that was not "risky", which put caution entries behind a
-    /// button labelled "Clean Safe Caches": Xcode Archives (the dSYMs you need to symbolicate
-    /// released crash reports), Android AVDs, Cursor and Windsurf workspace state, and the
-    /// language-version managers. One click, and none of it comes back on its own. Caution
-    /// entries now require the user to pick them deliberately, one at a time.
-    func cleanSafeCaches() {
-        cleanCaches(devCaches.filter { $0.riskLevel == "safe" }, title: "Safe caches")
-    }
-
-    /// Clean ALL caches including risky ones (requires explicit user confirmation)
-    func cleanAllDevCaches() {
-        cleanCaches(devCaches, title: "All developer caches")
+    /// Clean a caller-selected snapshot as one operation and perform one rescan when it finishes.
+    func cleanSelectedCaches(_ caches: [DevCache]) {
+        guard let first = caches.first else { return }
+        cleanCaches(caches, title: caches.count == 1 ? first.name : "Selected caches")
     }
 
     /// `caches` is snapshotted by the caller on the main thread — never read the @Published
@@ -908,7 +966,8 @@ class DiskMonitor: ObservableObject {
                 self.finishClean(
                     title: "Trash",
                     freed: max(0, sizeBefore - remaining),
-                    failure: remaining > 0 ? "Some items in the Trash could not be removed." : nil
+                    failure: remaining > 0 ? "Some items in the Trash could not be removed." : nil,
+                    outcome: .reclaimedSpace
                 )
             }
         }
@@ -1267,6 +1326,11 @@ enum PermissionState: String {
     case denied = "Denied"
 }
 
+enum CleanOutcome {
+    case movedToTrash
+    case reclaimedSpace
+}
+
 // MARK: - Models
 struct DiskCategory: Identifiable {
     let id = UUID()
@@ -1317,7 +1381,7 @@ struct LargeFile: Identifiable {
 }
 
 /// A clean that did not free what it promised — the item is still on disk.
-/// Surfaced to the user instead of being swallowed, so "Recovered X!" always means it really went.
+/// Surfaced to the user instead of being swallowed, so a success banner always means it really moved.
 struct CleanFailure: Identifiable {
     let id = UUID()
     let title: String      // what we tried to clean

--- a/Sources/ClearDisk/MainView.swift
+++ b/Sources/ClearDisk/MainView.swift
@@ -22,7 +22,6 @@ struct MainView: View {
     @ObservedObject var diskMonitor: DiskMonitor
     @State private var selectedTab: Tab = .developer
     @State private var showCleanConfirm = false
-    @State private var showCleanAllConfirm = false
     @State private var showCleanSafeConfirm = false
     @State private var activeProjectSheet: ActiveProjectSheet?
     @State private var cacheToClean: DevCache?
@@ -33,6 +32,10 @@ struct MainView: View {
     @State private var selectedArtifactIDs: Set<UUID> = []
     @State private var selectedCacheIDs: Set<UUID> = []
     @State private var showCleanSelectedCachesConfirm = false
+    @State private var showRiskyBulkConfirm = false
+    @State private var pendingBulkCaches: [DevCache] = []
+    @State private var acknowledgesDataLossRisk = false
+    @State private var showEmptyTrashConfirm = false
     @State private var showClearHistoryConfirm = false
     @State private var projectFilterMode: ProjectFilterMode = .all
     @State private var isCleaning = false
@@ -76,7 +79,7 @@ struct MainView: View {
     }
     
     var body: some View {
-        Group {
+        let base = Group {
             switch activeScreen {
             case .cleanCaches:
                 cleanCachesScreen
@@ -90,8 +93,13 @@ struct MainView: View {
         }
         .frame(width: Layout.popoverWidth, height: Layout.popoverHeight)
         .overlay {
-            if let sheet = activeProjectSheet {
-                projectSheetOverlay(sheet)
+            ZStack {
+                if let sheet = activeProjectSheet {
+                    projectSheetOverlay(sheet)
+                }
+                if showRiskyBulkConfirm {
+                    riskyBulkConfirmationOverlay
+                }
             }
         }
         // A popover that vanishes out from under a presentation leaves SwiftUI's state stranded,
@@ -99,6 +107,8 @@ struct MainView: View {
         .onReceive(NotificationCenter.default.publisher(for: .clearDiskPopoverDidClose)) { _ in
             dismissAllPresentations()
         }
+
+        let cacheAlerts = base
         .alert("Clear History?", isPresented: $showClearHistoryConfirm) {
             Button("Cancel", role: .cancel) { }
             Button("Clear", role: .destructive) {
@@ -129,8 +139,10 @@ struct MainView: View {
             Button("Cancel", role: .cancel) { }
             Button("Move to Trash", role: .destructive) {
                 isCleaning = true
-                diskMonitor.devCaches.removeAll { $0.riskLevel == "safe" }
-                diskMonitor.cleanSafeCaches()
+                let safeCaches = diskMonitor.devCaches.filter(DiskMonitor.isEligibleForSafeBulkClean)
+                let safeIDs = Set(safeCaches.map(\.id))
+                diskMonitor.devCaches.removeAll { safeIDs.contains($0.id) }
+                diskMonitor.cleanSelectedCaches(safeCaches)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) { isCleaning = false }
             }
         } message: {
@@ -141,48 +153,30 @@ struct MainView: View {
                 : ""
             Text("Clean \(safeCaches.count) safe caches?\nThis will move \(formatBytes(safeTotal)) to Trash.\n\n🟡 Caution and 🔴 risky caches are NOT included — select those individually.\nFiles go to Trash — you can recover them.\(xcodeWarning)")
         }
-        .alert("Clean ALL Developer Caches", isPresented: $showCleanAllConfirm) {
-            Button("Cancel", role: .cancel) { }
-            Button("Delete All (Including Risky)", role: .destructive) {
-                isCleaning = true
-                diskMonitor.devCaches.removeAll()
-                diskMonitor.cleanAllDevCaches()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { isCleaning = false }
-            }
-        } message: {
-            let total = diskMonitor.devCaches.reduce(Int64(0)) { $0 + $1.size }
-            let riskyCount = diskMonitor.devCaches.filter { $0.riskLevel == "risky" }.count
-            let riskyNote = riskyCount > 0 ? "\n\n🔴 WARNING: \(riskyCount) risky cache(s) included — may contain data that cannot be rebuilt (e.g. Docker volumes, unsaved projects)." : ""
-            let xcodeWarning = diskMonitor.isXcodeRunning()
-                ? "\n\n⚠️ Xcode is currently running! Close Xcode first for best results."
-                : ""
-            Text("Move ALL developer caches to Trash?\nThis will free \(formatBytes(total)).\n\n\(diskMonitor.devCaches.count) cache locations will be cleaned.\nFiles go to Trash — you can recover them.\(riskyNote)\(xcodeWarning)")
-        }
+
+        let cleanupAlerts = cacheAlerts
         .alert("Clean Selected Caches", isPresented: $showCleanSelectedCachesConfirm) {
-            Button("Cancel", role: .cancel) { }
+            Button("Cancel", role: .cancel) { pendingBulkCaches = [] }
             Button("Move to Trash", role: .destructive) {
-                isCleaning = true
-                let toClean = diskMonitor.devCaches.filter { selectedCacheIDs.contains($0.id) }
-                diskMonitor.devCaches.removeAll { selectedCacheIDs.contains($0.id) }
-                for cache in toClean {
-                    diskMonitor.cleanDevCache(cache)
-                }
-                selectedCacheIDs = []
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    isCleaning = false
-                    activeScreen = .main
-                }
+                performBulkClean(pendingBulkCaches)
             }
         } message: {
-            let toClean = diskMonitor.devCaches.filter { selectedCacheIDs.contains($0.id) }
-            let totalSize = toClean.reduce(Int64(0)) { $0 + $1.size }
-            let riskyCount = toClean.filter { $0.riskLevel == "risky" }.count
-            let riskyNote = riskyCount > 0 ? "\n\n🔴 WARNING: \(riskyCount) risky cache(s) selected — may contain data that cannot be rebuilt." : ""
+            let totalSize = pendingBulkCaches.reduce(Int64(0)) { $0 + $1.size }
             let xcodeWarning = diskMonitor.isXcodeRunning()
                 ? "\n\n⚠️ Xcode is currently running! Close Xcode first for best results."
                 : ""
-            Text("Clean \(toClean.count) selected cache(s)?\nThis will move \(formatBytes(totalSize)) to Trash.\n\nFiles go to Trash — you can recover them.\(riskyNote)\(xcodeWarning)")
+            Text("Clean \(pendingBulkCaches.count) selected cache(s)?\nThis will move \(formatBytes(totalSize)) to Trash. Disk space is reclaimed only after Trash is emptied.\(xcodeWarning)")
         }
+        .alert("Permanently Empty Trash?", isPresented: $showEmptyTrashConfirm) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete Permanently", role: .destructive) {
+                diskMonitor.emptyTrash()
+            }
+        } message: {
+            Text("This permanently deletes all \(formatBytes(diskMonitor.trashSizeBytes)) in your Mac's Trash — including items not moved there by ClearDisk. This cannot be undone.")
+        }
+
+        return cleanupAlerts
         .alert("Delete File", isPresented: $showDeleteFileConfirm) {
             Button("Cancel", role: .cancel) { }
             Button("Move to Trash", role: .destructive) {
@@ -197,7 +191,7 @@ struct MainView: View {
             }
         }
         // A clean that frees nothing must say so. Previously the failure was only printed to
-        // stdout, so the app showed "Recovered X!" while the files were still on disk.
+        // stdout, so the app showed a success while the files were still on disk.
         .alert(
             "Couldn't Move to Trash",
             isPresented: Binding(
@@ -267,16 +261,123 @@ struct MainView: View {
         .frame(width: Layout.popoverWidth, height: Layout.popoverHeight)
     }
 
+    private var riskyBulkConfirmationOverlay: some View {
+        let riskyCaches = pendingBulkCaches.filter { $0.riskLevel == "risky" }
+        let totalSize = pendingBulkCaches.reduce(Int64(0)) { $0 + $1.size }
+
+        return ZStack {
+            Color.black.opacity(0.55)
+
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.red)
+                    Text("Risk of Data Loss")
+                        .font(.system(size: 15, weight: .bold))
+                }
+
+                Text("The red items below may contain sessions, workspace state, containers, volumes, or other data that cannot be rebuilt.")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(riskyCaches) { cache in
+                            HStack(spacing: 6) {
+                                Circle().fill(Color.red).frame(width: 7, height: 7)
+                                Text(cache.name)
+                                    .font(.system(size: 11, weight: .medium))
+                                Spacer()
+                                Text(formatBytes(cache.size))
+                                    .font(.system(size: 10, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+                .frame(maxHeight: 130)
+
+                Toggle(isOn: $acknowledgesDataLossRisk) {
+                    Text("I understand these items may contain irreplaceable data, and I accept the risk of data loss.")
+                        .font(.system(size: 11, weight: .medium))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .toggleStyle(.checkbox)
+
+                Text("\(pendingBulkCaches.count) items · \(formatBytes(totalSize)) will be moved to Trash. Space is not reclaimed until Trash is emptied.")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+
+                HStack {
+                    Button("Cancel") {
+                        cancelRiskyBulkConfirmation()
+                    }
+                    .keyboardShortcut(.cancelAction)
+
+                    Spacer()
+
+                    Button("Move to Trash", role: .destructive) {
+                        let caches = pendingBulkCaches
+                        cancelRiskyBulkConfirmation(clearPending: false)
+                        performBulkClean(caches)
+                    }
+                    .disabled(!acknowledgesDataLossRisk)
+                }
+            }
+            .padding(16)
+            .frame(width: Layout.popoverWidth - 32)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .strokeBorder(Color.red.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.35), radius: 18, y: 6)
+        }
+        .frame(width: Layout.popoverWidth, height: Layout.popoverHeight)
+    }
+
+    private func requestBulkClean(_ caches: [DevCache]) {
+        guard !caches.isEmpty else { return }
+        pendingBulkCaches = caches
+        if DiskMonitor.requiresDataLossAcknowledgement(for: caches) {
+            acknowledgesDataLossRisk = false
+            showRiskyBulkConfirm = true
+        } else {
+            showCleanSelectedCachesConfirm = true
+        }
+    }
+
+    private func performBulkClean(_ caches: [DevCache]) {
+        guard !caches.isEmpty else { return }
+        let ids = Set(caches.map(\.id))
+        isCleaning = true
+        diskMonitor.devCaches.removeAll { ids.contains($0.id) }
+        diskMonitor.cleanSelectedCaches(caches)
+        selectedCacheIDs = []
+        pendingBulkCaches = []
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            isCleaning = false
+            activeScreen = .main
+        }
+    }
+
+    private func cancelRiskyBulkConfirmation(clearPending: Bool = true) {
+        showRiskyBulkConfirm = false
+        acknowledgesDataLossRisk = false
+        if clearPending { pendingBulkCaches = [] }
+    }
+
     /// Closes every modal layer. Called when the popover goes away so it can never reopen
     /// into a half-presented state.
     private func dismissAllPresentations() {
         activeProjectSheet = nil
         showCleanConfirm = false
-        showCleanAllConfirm = false
         showCleanSafeConfirm = false
         showCleanSelectedCachesConfirm = false
+        showEmptyTrashConfirm = false
         showClearHistoryConfirm = false
         showDeleteFileConfirm = false
+        cancelRiskyBulkConfirmation()
         diskMonitor.cleanFailure = nil
     }
 
@@ -420,7 +521,7 @@ struct MainView: View {
         let cautionDevTotal = diskMonitor.devCaches.filter { $0.riskLevel == "caution" }.reduce(Int64(0)) { $0 + $1.size }
         let riskyDevTotal = diskMonitor.devCaches.filter { $0.riskLevel == "risky" }.reduce(Int64(0)) { $0 + $1.size }
         let artifactTotal = diskMonitor.projectArtifacts.reduce(Int64(0)) { $0 + $1.size }
-        let trashTotal = diskMonitor.trashSize()
+        let trashTotal = diskMonitor.trashSizeBytes
         let grandTotal = safeDevTotal + cautionDevTotal + riskyDevTotal + artifactTotal + trashTotal
         
         return VStack(spacing: 8) {
@@ -683,15 +784,24 @@ struct MainView: View {
     // MARK: - Overview Tab
     var overviewContent: some View {
         VStack(spacing: 0) {
-            // Recovered banner
-            if diskMonitor.showRecoveredBanner && diskMonitor.lastCleanedAmount > 0 {
+            // Cleanup result banner
+            if diskMonitor.showCleanResultBanner && diskMonitor.lastCleanedAmount > 0 {
                 HStack(spacing: 8) {
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 14))
                         .foregroundColor(.green)
-                    Text("Recovered \(formatBytes(diskMonitor.lastCleanedAmount))!")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.green)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(diskMonitor.lastCleanOutcome == .reclaimedSpace
+                             ? "Reclaimed \(formatBytes(diskMonitor.lastCleanedAmount))"
+                             : "Moved \(formatBytes(diskMonitor.lastCleanedAmount)) to Trash")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.green)
+                        if diskMonitor.lastCleanOutcome == .movedToTrash {
+                            Text("Empty Trash to reclaim this disk space.")
+                                .font(.system(size: 9))
+                                .foregroundColor(.secondary)
+                        }
+                    }
                     Spacer()
                 }
                 .padding(.horizontal, 12)
@@ -707,7 +817,7 @@ struct MainView: View {
             }
             
             // Trash
-            let trash = diskMonitor.trashSize()
+            let trash = diskMonitor.trashSizeBytes
             if trash > 0 {
                 HStack(spacing: 8) {
                     Image(systemName: "trash.fill")
@@ -733,7 +843,7 @@ struct MainView: View {
                         .frame(width: 65, alignment: .trailing)
                     
                     Button("Empty") {
-                        diskMonitor.emptyTrash()
+                        showEmptyTrashConfirm = true
                     }
                     .font(.system(size: 10))
                     .controlSize(.mini)
@@ -1038,7 +1148,7 @@ struct MainView: View {
                 // Clean entire group
                 Button(action: {
                     selectedCacheIDs = Set(caches.map { $0.id })
-                    showCleanSelectedCachesConfirm = true
+                    requestBulkClean(caches)
                 }) {
                     Image(systemName: "trash")
                         .font(.system(size: 11))
@@ -1469,7 +1579,7 @@ struct MainView: View {
                 
                 VStack(alignment: .leading, spacing: 10) {
                     onboardingFeature(icon: "magnifyingglass", text: "Scans developer caches (Xcode, npm, pip, etc.)")
-                    onboardingFeature(icon: "trash", text: "Safely moves files to Trash (always recoverable)")
+                    onboardingFeature(icon: "trash", text: "Moves files to Trash before permanent deletion")
                     onboardingFeature(icon: "bell", text: "Alerts when disk space is running low")
                     onboardingFeature(icon: "chart.line.uptrend.xyaxis", text: "Forecasts when your disk will be full")
                 }
@@ -1977,7 +2087,8 @@ struct MainView: View {
             .padding(.top, 6)
             
             Button(action: {
-                showCleanSelectedCachesConfirm = true
+                let selected = cachesToShow.filter { selectedCacheIDs.contains($0.id) }
+                requestBulkClean(selected)
             }) {
                 HStack(spacing: 6) {
                     if isCleaning {
@@ -2243,14 +2354,14 @@ struct MainView: View {
     // MARK: - Footer
     var footerView: some View {
         HStack {
-            if diskMonitor.totalSavedAllTime > 0 {
+            if diskMonitor.totalMovedToTrash > 0 {
                 HStack(spacing: 4) {
-                    Image(systemName: "leaf.fill")
+                    Image(systemName: "trash.fill")
                         .font(.system(size: 9))
-                        .foregroundColor(.green)
-                    Text("Total saved: \(formatBytes(diskMonitor.totalSavedAllTime))")
+                        .foregroundColor(.secondary)
+                    Text("Moved via ClearDisk: \(formatBytes(diskMonitor.totalMovedToTrash))")
                         .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(.green)
+                        .foregroundColor(.secondary)
                 }
             } else {
                 Text("ClearDisk \(AppInfo.displayVersion)")

--- a/Tests/ClearDiskTests/CleanupSafetyTests.swift
+++ b/Tests/ClearDiskTests/CleanupSafetyTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import ClearDisk
+
+final class CleanupSafetyTests: XCTestCase {
+    private func cache(name: String, risk: String) -> DevCache {
+        DevCache(
+            name: name,
+            icon: "externaldrive",
+            path: "/tmp/\(name)",
+            size: 1,
+            lastAccessed: nil,
+            daysSinceAccess: nil,
+            suggestion: nil,
+            riskLevel: risk,
+            cacheDescription: "",
+            group: nil
+        )
+    }
+
+    func testSafeBulkCleanOnlyAcceptsExplicitlySafeItems() {
+        XCTAssertTrue(DiskMonitor.isEligibleForSafeBulkClean(cache(name: "Safe", risk: "safe")))
+        XCTAssertFalse(DiskMonitor.isEligibleForSafeBulkClean(cache(name: "Caution", risk: "caution")))
+        XCTAssertFalse(DiskMonitor.isEligibleForSafeBulkClean(cache(name: "Risky", risk: "risky")))
+    }
+
+    func testRiskySelectionRequiresAcknowledgement() {
+        XCTAssertFalse(DiskMonitor.requiresDataLossAcknowledgement(for: [cache(name: "Safe", risk: "safe")]))
+        XCTAssertTrue(DiskMonitor.requiresDataLossAcknowledgement(for: [
+            cache(name: "Safe", risk: "safe"),
+            cache(name: "Docker", risk: "risky")
+        ]))
+    }
+
+    func testKnownUserDataStoresStayRisky() {
+        let definitions = Dictionary(
+            uniqueKeysWithValues: DiskMonitor().allCachePaths().map { ($0.name, $0.riskLevel) }
+        )
+        for name in ["Docker (Data)", "Claude Desktop", "Claude Code", "Cursor", "Windsurf"] {
+            XCTAssertEqual(definitions[name], "risky", "\(name) must never enter a one-click safe cleanup")
+        }
+    }
+
+    func testCacheDefinitionsNeverTargetBroadUserDirectories() {
+        let paths = DiskMonitor().allCachePaths().map(\.path)
+        let forbiddenSuffixes = ["/Library", "/Library/Application Support", "/Documents", "/Desktop", "/Downloads"]
+        XCTAssertEqual(paths.count, Set(paths).count, "Cleanup paths must be unique")
+        XCTAssertFalse(paths.contains("/"), "A cleanup definition targets the filesystem root")
+        for path in paths {
+            XCTAssertFalse(
+                forbiddenSuffixes.contains { path.hasSuffix($0) },
+                "A cleanup definition targets a dangerously broad directory"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Tightens cleanup confirmation and result handling while separating lightweight storage refreshes from full scans.

- Refresh available space every 5 minutes
- Run the full cache and project scan every 30 minutes
- Require explicit confirmation for risky bulk cleanup
- Add regression coverage for cleanup safety

Tested with `swift build`.