### PR TITLE
Add NuGet cache support for .NET projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Your Mac's SSD is full of developer caches you forgot about. Xcode DerivedData a
 - **CleanMyMac** ($40/yr) — bloated, expensive, trust issues
 - **SquirrelDisk** — dead (3 years, no updates)
 
-ClearDisk scans **75 developer cache paths** in one tool. Lives in your menu bar. Alerts you when disk gets full.
+ClearDisk scans **79 developer cache paths** in one tool. Lives in your menu bar. Alerts you when disk gets full.
 
 ## Features
 
-- **75 Developer Caches** — Xcode (DerivedData, Archives, Simulators, Caches, Device Support, Logs, Previews), Swift PM, CocoaPods, Carthage, Homebrew, npm, Yarn, pnpm (store *and* cache), Bun, Deno, node-gyp, TypeScript, pip, UV, Conda, Poetry, pipenv, Gradle, Maven, SBT/Ivy, Gradle Wrapper, Docker, Terraform, Composer, .NET NuGet, Go (modules *and* build cache), Rust Cargo, Bazel, Flutter/Pub, JetBrains, Ruby (Gems, rbenv, mise, RVM, Bundler), Android (Emulators, System Images, NDK), Testing (Playwright, Puppeteer, Prisma), AI Tools (Claude Desktop, Claude Code, Ollama, HuggingFace, ChatGPT, Cursor, Windsurf), VS Code (Cache, CachedData, Extensions, Chromium Cache, Logs, Updater), Game Engines (Unity, Unity Hub, Godot), Version Managers (nvm, pyenv, mise, rustup), Cloud (AWS CLI)
+- **79 Developer Caches** — Xcode (DerivedData, Archives, Simulators, Caches, Device Support, Logs, Previews), Swift PM, CocoaPods, Carthage, Homebrew, npm, Yarn, pnpm (store *and* cache), Bun, Deno, node-gyp, TypeScript, pip, UV, Conda, Poetry, pipenv, Gradle, Maven, SBT/Ivy, Gradle Wrapper, Docker, Terraform, Composer, .NET NuGet, Go (modules *and* build cache), Rust Cargo, Bazel, Flutter/Pub, JetBrains, Ruby (Gems, rbenv, mise, RVM, Bundler), Android (Emulators, System Images, NDK), Testing (Playwright, Puppeteer, Prisma), AI Tools (Claude Desktop, Claude Code, Ollama, HuggingFace, ChatGPT, Cursor, Windsurf), VS Code (Cache, CachedData, Extensions, Chromium Cache, Logs, Updater), Game Engines (Unity, Unity Hub, Godot), Version Managers (nvm, pyenv, mise, rustup), Cloud (AWS CLI)
 - **Project Artifact Scanner** — Finds stale per-project caches in your project folders, including repositories kept directly in your home directory. Detects **23 project types**: Node.js / JS (incl. `.next`, `.nuxt`, `.svelte-kit`, `.angular`, `.turbo`, `.vite`, `.parcel-cache`, `.yarn/cache`, `dist`, `build`), **Python (`.venv`, `venv`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.tox`, `*.egg-info`)**, Rust, Swift PM, **CocoaPods (`Pods/`)**, **Carthage**, **Xcode (in-project `build/`, `DerivedData/`)**, Go, Gradle (Java + Kotlin), Maven, PHP/Composer, Ruby, Flutter/Dart, CMake, Terraform, **.NET / C# (`bin/`, `obj/`)**, **Godot (`.godot/`, `.import/`)**, **Unity (`Library/`, `Temp/`, `Logs/`)**, **Unreal (`Binaries/`, `Intermediate/`, `DerivedDataCache/`)**, Haskell, Elixir, Zig, Crystal. Each project can expose multiple artifacts (e.g. a Next.js project shows `node_modules` *and* `.next` *and* `dist` separately).
 - **Cache Descriptions** — Every cache shows a human-readable explanation ("Downloaded Swift packages. Re-downloads on next build.") so you know exactly what you're deleting
 - **DerivedData Project Breakdown** — Shows which projects live inside DerivedData (e.g. "MyApp: 2.3 GB, OtherApp: 1.1 GB") by reading `info.plist`
@@ -65,7 +65,7 @@ ClearDisk scans **75 developer cache paths** in one tool. Lives in your menu bar
 | Cache descriptions | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Storage forecast | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Safe delete (Trash) | ✅ | ❌ `removeItem` | ❌ `rm -rf` | ❌ `rm -rf` | ❌ `rm -rf` | N/A | ❌ |
-| Total cache paths | 75 | 6 | 50+ | 24 types | 42 modules | 0 | Unknown |
+| Total cache paths | 79 | 6 | 50+ | 24 types | 42 modules | 0 | Unknown |
 | Price | Free | Free | Free | Free | Free | $10 | $40/yr |
 | Open source | ✅ MIT | ✅ GPL-3 | ✅ MIT | ✅ MIT | ✅ Apache-2 | ❌ | ❌ |
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Your Mac's SSD is full of developer caches you forgot about. Xcode DerivedData a
 - **CleanMyMac** ($40/yr) — bloated, expensive, trust issues
 - **SquirrelDisk** — dead (3 years, no updates)
 
-ClearDisk scans **74 developer cache paths** in one tool. Lives in your menu bar. Alerts you when disk gets full.
+ClearDisk scans **75 developer cache paths** in one tool. Lives in your menu bar. Alerts you when disk gets full.
 
 ## Features
 
-- **74 Developer Caches** — Xcode (DerivedData, Archives, Simulators, Caches, Device Support, Logs, Previews), Swift PM, CocoaPods, Carthage, Homebrew, npm, Yarn, pnpm (store *and* cache), Bun, Deno, node-gyp, TypeScript, pip, UV, Conda, Poetry, pipenv, Gradle, Maven, SBT/Ivy, Gradle Wrapper, Docker, Terraform, Composer, Go (modules *and* build cache), Rust Cargo, Bazel, Flutter/Pub, JetBrains, Ruby (Gems, rbenv, mise, RVM, Bundler), Android (Emulators, System Images, NDK), Testing (Playwright, Puppeteer, Prisma), AI Tools (Claude Desktop, Claude Code, Ollama, HuggingFace, ChatGPT, Cursor, Windsurf), VS Code (Cache, CachedData, Extensions, Chromium Cache, Logs, Updater), Game Engines (Unity, Unity Hub, Godot), Version Managers (nvm, pyenv, mise, rustup), Cloud (AWS CLI)
+- **75 Developer Caches** — Xcode (DerivedData, Archives, Simulators, Caches, Device Support, Logs, Previews), Swift PM, CocoaPods, Carthage, Homebrew, npm, Yarn, pnpm (store *and* cache), Bun, Deno, node-gyp, TypeScript, pip, UV, Conda, Poetry, pipenv, Gradle, Maven, SBT/Ivy, Gradle Wrapper, Docker, Terraform, Composer, .NET NuGet, Go (modules *and* build cache), Rust Cargo, Bazel, Flutter/Pub, JetBrains, Ruby (Gems, rbenv, mise, RVM, Bundler), Android (Emulators, System Images, NDK), Testing (Playwright, Puppeteer, Prisma), AI Tools (Claude Desktop, Claude Code, Ollama, HuggingFace, ChatGPT, Cursor, Windsurf), VS Code (Cache, CachedData, Extensions, Chromium Cache, Logs, Updater), Game Engines (Unity, Unity Hub, Godot), Version Managers (nvm, pyenv, mise, rustup), Cloud (AWS CLI)
 - **Project Artifact Scanner** — Finds stale per-project caches in your project folders, including repositories kept directly in your home directory. Detects **23 project types**: Node.js / JS (incl. `.next`, `.nuxt`, `.svelte-kit`, `.angular`, `.turbo`, `.vite`, `.parcel-cache`, `.yarn/cache`, `dist`, `build`), **Python (`.venv`, `venv`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.tox`, `*.egg-info`)**, Rust, Swift PM, **CocoaPods (`Pods/`)**, **Carthage**, **Xcode (in-project `build/`, `DerivedData/`)**, Go, Gradle (Java + Kotlin), Maven, PHP/Composer, Ruby, Flutter/Dart, CMake, Terraform, **.NET / C# (`bin/`, `obj/`)**, **Godot (`.godot/`, `.import/`)**, **Unity (`Library/`, `Temp/`, `Logs/`)**, **Unreal (`Binaries/`, `Intermediate/`, `DerivedDataCache/`)**, Haskell, Elixir, Zig, Crystal. Each project can expose multiple artifacts (e.g. a Next.js project shows `node_modules` *and* `.next` *and* `dist` separately).
 - **Cache Descriptions** — Every cache shows a human-readable explanation ("Downloaded Swift packages. Re-downloads on next build.") so you know exactly what you're deleting
 - **DerivedData Project Breakdown** — Shows which projects live inside DerivedData (e.g. "MyApp: 2.3 GB, OtherApp: 1.1 GB") by reading `info.plist`
@@ -65,7 +65,7 @@ ClearDisk scans **74 developer cache paths** in one tool. Lives in your menu bar
 | Cache descriptions | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Storage forecast | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Safe delete (Trash) | ✅ | ❌ `removeItem` | ❌ `rm -rf` | ❌ `rm -rf` | ❌ `rm -rf` | N/A | ❌ |
-| Total cache paths | 74 | 6 | 50+ | 24 types | 42 modules | 0 | Unknown |
+| Total cache paths | 75 | 6 | 50+ | 24 types | 42 modules | 0 | Unknown |
 | Price | Free | Free | Free | Free | Free | $10 | $40/yr |
 | Open source | ✅ MIT | ✅ GPL-3 | ✅ MIT | ✅ MIT | ✅ Apache-2 | ❌ | ❌ |
 

--- a/Sources/ClearDisk/DiskMonitor.swift
+++ b/Sources/ClearDisk/DiskMonitor.swift
@@ -468,6 +468,7 @@ class DiskMonitor: ObservableObject {
         "Docker (Data)": "Docker images, containers, and volumes. May lose running containers and uncommitted data!",
         "Terraform Plugins": "Terraform/OpenTofu CLI plugins and provider cache. Re-downloads on terraform init.",
         "Composer Cache": "Cached PHP packages. Re-downloads on composer install.",
+        ".NET NuGet": "Restored NuGet packages for .NET projects, one copy per package version. Re-downloads on dotnet restore.",
         "Go Modules": "Go module download cache. Re-downloads on go mod download.",
         "Go Build Cache": "Compiled package objects that make rebuilds fast (GOCACHE). Rebuilds itself — the first build after clearing is slower. Equivalent to go clean -cache.",
         "Rust Cargo": "Cached crate sources and registries. Re-downloads on cargo build.",
@@ -619,6 +620,11 @@ class DiskMonitor: ObservableObject {
             ("Terraform Plugins", "server.rack", "\(home)/.terraform.d", "caution", nil),
             // PHP
             ("Composer Cache", "music.note.list", "\(home)/.composer/cache", "safe", nil),
+            // .NET
+            // ~/.nuget/packages is the global-packages folder, not ~/.nuget itself (which also holds
+            // NuGet.Config). Unlike Go's module cache, NuGet does not check the extracted packages out
+            // read-only, so there is no Trash-move restriction here.
+            (".NET NuGet", "square.grid.2x2.fill", "\(home)/.nuget/packages", "safe", nil),
             // Go/Rust
             // Deliberately the download cache and not all of ~/go/pkg/mod. The extracted modules beside it
             // are checked out read-only (0555 dirs), and macOS refuses to move a directory it cannot write

--- a/Tests/ClearDiskTests/CleanupSafetyTests.swift
+++ b/Tests/ClearDiskTests/CleanupSafetyTests.swift
@@ -40,6 +40,19 @@ final class CleanupSafetyTests: XCTestCase {
         }
     }
 
+    func testEveryCacheDefinitionHasADescription() {
+        // MainView renders `DiskMonitor.cacheDescriptions[entry.name] ?? ""` — a name added to
+        // allCachePaths() without a matching key here silently shows a blank description instead
+        // of failing to build.
+        let names = DiskMonitor().allCachePaths().map(\.name)
+        for name in names {
+            XCTAssertNotNil(
+                DiskMonitor.cacheDescriptions[name],
+                "\(name) is missing an entry in cacheDescriptions"
+            )
+        }
+    }
+
     func testCacheDefinitionsNeverTargetBroadUserDirectories() {
         let paths = DiskMonitor().allCachePaths().map(\.path)
         let forbiddenSuffixes = ["/Library", "/Library/Application Support", "/Documents", "/Desktop", "/Downloads"]

--- a/Tests/ClearDiskTests/CleanupSafetyTests.swift
+++ b/Tests/ClearDiskTests/CleanupSafetyTests.swift
@@ -40,7 +40,7 @@ final class CleanupSafetyTests: XCTestCase {
         }
     }
 
-    func testEveryCacheDefinitionHasADescription() {
+    func testEveryDeveloperCacheDefinitionHasADescription() {
         // MainView renders `DiskMonitor.cacheDescriptions[entry.name] ?? ""` — a name added to
         // allCachePaths() without a matching key here silently shows a blank description instead
         // of failing to build.


### PR DESCRIPTION
Closes #4.

## What changed

- Adds the default NuGet global-packages folder at `~/.nuget/packages` without targeting `~/.nuget` or `NuGet.Config`.
- Classifies it as rebuildable because required packages return on the next restore.
- Adds the matching cache description.
- Adds a regression test for missing developer-cache descriptions.
- Updates the documented developer cache count to 79 for the current catalog.

The contributor branch has been updated with the current `main`.

## Verification

- Path and restore behavior verified against current Microsoft NuGet documentation
- Clean `swift build` against current `main`
- This Mac does not have the .NET SDK or a local NuGet cache, so no destructive runtime cleanup test was performed