### PR TITLE
Add common project scan roots

### DIFF
--- a/Sources/ClearDisk/DiskMonitor.swift
+++ b/Sources/ClearDisk/DiskMonitor.swift
@@ -1143,6 +1143,8 @@ class DiskMonitor: ObservableObject {
             "\(home)/src",
             "\(home)/workspace",
             "\(home)/Desktop",
+            "\(home)/Development",
+            "\(home)/dev",
         ]
     }
 
@@ -1150,7 +1152,7 @@ class DiskMonitor: ObservableObject {
     /// roots that are already scanned in full above. Without this they would be walked twice.
     private static let homeScanExclusions: Set<String> = [
         "Library", "Documents", "Desktop", "Downloads", "Movies", "Music", "Pictures",
-        "Public", "Applications", "Developer", "Projects", "Code", "repos", "src", "workspace",
+        "Public", "Applications", "Developer", "Projects", "Code", "repos", "src", "workspace", "Development", "dev",
     ]
 
     private func scanProjectArtifacts() {


### PR DESCRIPTION
## What changed

Adds `~/Development` and `~/dev` to the full project scan roots, and excludes both from the shallow home scan so projects are discovered without duplicate traversal.

The contributor branch has been updated with the current `main`.

## Verification

- Clean `swift build` against current `main`
- Final PR diff is limited to the two roots and matching exclusions